### PR TITLE
Feat - Added fromJS function to rebuild nested records for a given tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 typings/
 npm-debug.log
 .nyc_output/
+coverage/

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,7 @@
 export {
   makeTypedFactory,
   recordify,
+  fromJS
 } from './src/typed.factory';
 
 export { TypedRecord } from './src/typed.record';

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "Factory for Typed Immutablejs.Record",
   "main": "./dist/index.js",
   "scripts": {
+    "postinstall": "npm run typings",
     "build": "npm run typings && rimraf ./dist; tsc;",
-    "test": "npm run typings  && npm run lint && nyc npm run mocha",
-    "typings": "rimraf ./typings && typings install",
+    "test": "rimraf ./coverage && npm run lint && nyc npm run mocha",
+    "typings": "rimraf ./typings && typings install && npm uninstall @types/chai; tsc; npm install @types/chai@3.4.31",
     "mocha": "mocha  --opts ./test/mocha.opts",
     "lint": "tslint 'src/**/*.ts' 'test/**/*/.ts'"
   },
@@ -27,18 +28,50 @@
   },
   "homepage": "https://github.com/rangle/typed-immutable-record#readme",
   "devDependencies": {
+    "@types/chai": "^3.4.31",
+    "@types/mocha": "^2.2.30",
+    "@types/node": "^6.0.36",
+    "awesome-typescript-loader": "^3.0.0-beta.9",
     "chai": "^3.5.0",
     "immutable": "3.8.1",
     "mocha": "^2.5.3",
     "nyc": "^8.1.0",
     "rimraf": "^2.5.4",
-    "ts-loader": "^0.8.2",
     "ts-node": "^1.3.0",
     "tslint": "^3.13.0",
-    "typescript": "^2.0.0",
+    "typescript": "^2.1.4",
     "typings": "^1.3.2"
   },
   "peerDependencies": {
     "immutable": "^3.8.1"
+  },
+  "dependencies": {
+    "ramda": "^0.22.1"
+  },
+  "nyc": {
+    "exclude": [
+      "node_modules",
+      "test",
+      "coverage",
+      ".nyc_output",
+      "dist",
+      "typings"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "require": [
+      "ts-node/register"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "all": true,
+    "check-coverage": false,
+    "lines": 60,
+    "branches": 60,
+    "functions": 60,
+    "statements": 60
   }
 }

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,2 @@
 --compilers ts:ts-node/register
---compilers tsx:ts-node/register
 **/*.test.ts

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,6 @@
     "no-arg": true,
     "no-bitwise": true,
     "no-console": [1,
-      "log",
       "debug",
       "info",
       "time",

--- a/typings.json
+++ b/typings.json
@@ -1,8 +1,7 @@
 {
   "name": "typed-immutable-record",
   "version": false,
-  "globalDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "mocha": "registry:dt/mocha#2.2.5+20160619032855"
+  "dependencies": {
+    "ramda": "registry:npm/ramda#0.21.0+20160531162943"
   }
 }


### PR DESCRIPTION
@SethDavenport @egervari 
The intent of this code is to have a way to rebuild nested records, either having an array (that will become a List) or an object associated with a factory. In order to do so, some sort of data structure that define how the Factories are nested is required.
There is a new function in the library code and a new test the uses it.
Let me know your thoughts, this is a recurrent issue and there are several people looking for a better way to revive some JS object.