### PR TITLE
Update typings so that set/delete/remove will throw a error if the st…

### DIFF
--- a/src/typed.record.ts
+++ b/src/typed.record.ts
@@ -34,9 +34,9 @@ import {
 export interface TypedRecord<T extends TypedRecord<T>>
   extends Map<string, any> {
 
-  set: (prop: string, val: any) => T;
-  delete: (key: string) => T;
-  remove: (key: string) => T;
+  set: <K extends keyof T>(prop: K, val: any) => T;
+  delete: <K extends keyof T>(key: K) => T;
+  remove: <K extends keyof T>(key: K) => T;
   clear: () => T;
   update: {
     (updater: (value: T) => any): T;


### PR DESCRIPTION
Love the library man thanks.

Updated typings so that set,delete,remove can only accept keys of the Record.
Please push this to the npm package i have a project that has implemented your library.

this is useful because code such as  Record.set("STRING", value) will now fail if "STRING" isn't a key of the record.