### PR TITLE
Adding type-guarded alternative to set(key,val)

### DIFF
--- a/src/typed.factory.ts
+++ b/src/typed.factory.ts
@@ -1,6 +1,7 @@
-import {TypedRecord} from './typed.record';
-import {Record} from 'immutable';
+import { TypedRecord } from './typed.record';
+import { Record } from 'immutable';
 
+/* tslint:disable:no-any */
 
 /**
  * Creates a factory function you can use to make TypedRecords.
@@ -36,10 +37,23 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
   (obj: E, name?: string): (val?: E) => T {
 
   const ImmutableRecord = Record(obj, name);
-  return function TypedFactory(val: E = null): T {
-    return new ImmutableRecord(val) as T;
+
+  return function TypedFactory(val: E): T {
+    let immutableRecord = new ImmutableRecord(val) as T;
+    let l = {};
+    for (let key of Object.keys(obj)) {
+      l = Object.defineProperty(l, key, {
+        value: {
+          be: (newValue: any) => immutableRecord.set(key, newValue)
+        }
+      });
+    }
+    immutableRecord = Object.defineProperty(immutableRecord, 'let', {
+      value: l
+    });
+    return immutableRecord;
   };
-};
+}
 
 /**
  * Utility function to generate an Immutable.Record for the provided type.
@@ -66,9 +80,9 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
  */
 export function recordify<E, T extends TypedRecord<T> & E>(
   defaultVal: E,
-  val: E = null,
+  val: E,
   name?: string): T {
 
   const TypedRecordFactory = makeTypedFactory<E, T>(defaultVal, name);
   return val ? TypedRecordFactory(val) : TypedRecordFactory();
-};
+}

--- a/src/typed.factory.ts
+++ b/src/typed.factory.ts
@@ -1,5 +1,5 @@
-import { TypedRecord } from './typed.record';
-import { Record } from 'immutable';
+import {TypedRecord} from './typed.record';
+import {Record} from 'immutable';
 
 /* tslint:disable:no-any */
 
@@ -38,7 +38,7 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
 
   const ImmutableRecord = Record(obj, name);
 
-  return function TypedFactory(val: E): T {
+  return function TypedFactory(val: E = null): T {
     let immutableRecord = new ImmutableRecord(val) as T;
     let l = {};
     for (let key of Object.keys(obj)) {
@@ -53,7 +53,7 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
     });
     return immutableRecord;
   };
-}
+};
 
 /**
  * Utility function to generate an Immutable.Record for the provided type.

--- a/src/typed.factory.ts
+++ b/src/typed.factory.ts
@@ -1,7 +1,6 @@
 import {TypedRecord} from './typed.record';
 import {Record} from 'immutable';
 
-/* tslint:disable:no-any */
 
 /**
  * Creates a factory function you can use to make TypedRecords.
@@ -80,9 +79,9 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
  */
 export function recordify<E, T extends TypedRecord<T> & E>(
   defaultVal: E,
-  val: E,
+  val: E = null,
   name?: string): T {
 
   const TypedRecordFactory = makeTypedFactory<E, T>(defaultVal, name);
   return val ? TypedRecordFactory(val) : TypedRecordFactory();
-}
+};

--- a/src/typed.factory.ts
+++ b/src/typed.factory.ts
@@ -36,7 +36,6 @@ export function makeTypedFactory<E, T extends TypedRecord<T> & E>
   (obj: E, name?: string): (val?: E) => T {
 
   const ImmutableRecord = Record(obj, name);
-
   return function TypedFactory(val: E = null): T {
     let immutableRecord = new ImmutableRecord(val) as T;
     let l = {};

--- a/src/typed.record.ts
+++ b/src/typed.record.ts
@@ -3,6 +3,7 @@ import {
   Iterable,
 } from 'immutable';
 
+
 /**
  * Interface that inherit from Immutable.Map that overrides all methods that
  * would return a new version of Immutable.Map itself to return <T> instead.
@@ -30,9 +31,6 @@ import {
  *
  * Examples in test file: 'test/typed.record.test.ts'
  */
-
-/* tslint:disable:no-any */
-
 export interface TypedRecord<T extends TypedRecord<T>>
   extends Map<string, any> {
 
@@ -76,4 +74,4 @@ export interface TypedRecord<T extends TypedRecord<T>>
       be: (value: T[P]) => T
     }
   };
-}
+};

--- a/src/typed.record.ts
+++ b/src/typed.record.ts
@@ -3,7 +3,6 @@ import {
   Iterable,
 } from 'immutable';
 
-
 /**
  * Interface that inherit from Immutable.Map that overrides all methods that
  * would return a new version of Immutable.Map itself to return <T> instead.
@@ -31,6 +30,9 @@ import {
  *
  * Examples in test file: 'test/typed.record.test.ts'
  */
+
+/* tslint:disable:no-any */
+
 export interface TypedRecord<T extends TypedRecord<T>>
   extends Map<string, any> {
 
@@ -69,4 +71,9 @@ export interface TypedRecord<T extends TypedRecord<T>>
   withMutations: (mutator: (mutable: T) => any) => T;
   asMutable: () => T;
   asImmutable: () => T;
-};
+  let: {
+    [P in keyof T]: {
+      be: (value: T[P]) => T
+    }
+  };
+}


### PR DESCRIPTION
First of, thanks for a nice library!

I felt like it would be useful to have `set(key,val)` give some type information about the `val` argument. Now obviously this would change depending on what `key` argument was given. For example if the base object was `{ name: string, id: number }`, the type of `val` should be `string` or `number`, depending on what the first argument was.

Naturally that doesn't really make sense. So instead I've tried to support the syntax `typedRecord.let.name.be('foo')` and `typedRecord.let.id.be(123)`, etc. I feel this is a useful addition - I would love to write a couple of tests for it aswell, but for some reason my npm is having trouble installing the dependencies, making it overly tedious.

Do you think this change would be nice?